### PR TITLE
Small fixes (hexjump start 0 not printed, y2j indent option not used)

### DIFF
--- a/ast/strings.go
+++ b/ast/strings.go
@@ -311,7 +311,7 @@ func (h *HexJump) WriteSource(w io.Writer) (err error) {
 	} else if h.Start == h.End {
 		_, err = fmt.Fprintf(w, "[%d] ", h.Start)
 	} else if h.Start == 0 {
-		_, err = fmt.Fprintf(w, "[-%d] ", h.End)
+		_, err = fmt.Fprintf(w, "[0-%d] ", h.End)
 	} else if h.End == 0 {
 		_, err = fmt.Fprintf(w, "[%d-] ", h.Start)
 	} else {

--- a/cmd/y2j/main.go
+++ b/cmd/y2j/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	jsonpb "github.com/golang/protobuf/jsonpb"
 	"io"
 	"os"
+
+	jsonpb "github.com/golang/protobuf/jsonpb"
 
 	"github.com/VirusTotal/gyp"
 )
@@ -42,7 +43,7 @@ func main() {
 	}
 
 	marshaler := jsonpb.Marshaler{
-		Indent: "  ",
+		Indent: opts.Indent,
 	}
 	err = marshaler.Marshal(out, ruleset.AsProto())
 	if err != nil {


### PR DESCRIPTION
When using jumps in hexstrings j2y emits [-<end>] instead of [0-<end>] when start of jump is 0. While this intuitively makes sense it is not supported by the Yara grammar.
Indent command-line option was not used in y2j.