### PR TITLE
Fix the encoding of meta strings when they contain unicode characters.

### DIFF
--- a/ast/meta.go
+++ b/ast/meta.go
@@ -2,10 +2,34 @@ package ast
 
 import (
 	"fmt"
-
 	"github.com/VirusTotal/gyp/pb"
 	"github.com/golang/protobuf/proto"
 )
+
+const (
+	lowerhex = "0123456789abcdef"
+)
+
+func toASCII(s string) string {
+	ascii := make([]byte, 0)
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '\n':
+			ascii = append(ascii, `\n`...)
+		case s[i] == '\r':
+			ascii = append(ascii, `\r`...)
+		case s[i] == '\t':
+			ascii = append(ascii, `\t`...)
+		case s[i] >= 32 && s[i] < 127:
+			ascii = append(ascii, s[i])
+		default:
+			ascii = append(ascii, `\x`...)
+			ascii = append(ascii, lowerhex[s[i]>>4])
+			ascii = append(ascii, lowerhex[s[i]&0xF])
+		}
+	}
+	return string(ascii)
+}
 
 // Meta represents an entry in a rule's metadata section. Each entry is
 // composed of a key and a value. The value can be either a string, an int64
@@ -18,7 +42,12 @@ type Meta struct {
 // String returns the string representation of a metadata entry.
 func (m *Meta) String() string {
 	// With %#v we print the Golang's representation of the value, which
-	// happens to be the same in YARA.
+	// happens to be the same in YARA. For values of string type we don't use
+	// %#v because Golang produces strings with escape sequences that are not
+	// supported by YARA, like \u00a0.
+	if s, isString := m.Value.(string); isString {
+		return fmt.Sprintf("%s = \"%s\"", m.Key, toASCII(s))
+	}
 	return fmt.Sprintf("%s = %#v", m.Key, m.Value)
 }
 

--- a/ast/meta.go
+++ b/ast/meta.go
@@ -11,7 +11,7 @@ const (
 )
 
 func toASCII(s string) string {
-	ascii := make([]byte, 0)
+	ascii := make([]byte, 0, len(s))
 	for i := 0; i < len(s); i++ {
 		switch {
 		case s[i] == '\n':

--- a/ast/rules_test.go
+++ b/ast/rules_test.go
@@ -84,7 +84,7 @@ global private rule foo : bar baz {
 			Identifier: "foo",
 			Meta: []*Meta{
 				&Meta{"foo", 1},
-				&Meta{"bar", "qux"},
+				&Meta{"bar", "qux\t\n\xc3\x00"},
 				&Meta{"baz", true},
 			},
 			Condition: KeywordTrue,
@@ -93,7 +93,7 @@ global private rule foo : bar baz {
 rule foo {
   meta:
     foo = 1
-    bar = "qux"
+    bar = "qux\t\n\xc3\x00"
     baz = true
   condition:
     true


### PR DESCRIPTION
We were relying on the use of Sprintf with the %#v format modifier, which produces the Golang literal representation of the string. This works fine for strings that are plain ASCII, but when they contain unicode characters it produces strings with escape sequences like \uXXXX that are not supported by YARA.