### PR TITLE
fix untyped int constant overflow for 386 arch

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -1208,7 +1208,7 @@ case 57:
       if v > math.MaxInt64 / 1024 {
         return Error(
           gyperror.IntegerOverflowError,
-          fmt.Sprintf("Found %s; Max: %d", YYtext, math.MaxInt64))
+          fmt.Sprintf("Found %s; Max: %d", YYtext, int64(math.MaxInt64)))
       } else {
         v *= 1024
       }
@@ -1216,7 +1216,7 @@ case 57:
       if v > math.MaxInt64 / 1048576 {
         return Error(
           gyperror.IntegerOverflowError,
-          fmt.Sprintf("Found %s; Max: %d", YYtext, math.MaxInt64))
+          fmt.Sprintf("Found %s; Max: %d", YYtext, int64(math.MaxInt64)))
       } else {
           v *= 1048576
       }

--- a/parser/lexer.l
+++ b/parser/lexer.l
@@ -263,7 +263,7 @@ u?int(8|16|32)(be)? {
       if v > math.MaxInt64 / 1024 {
         return Error(
           gyperror.IntegerOverflowError,
-          fmt.Sprintf("Found %s; Max: %d", YYtext, math.MaxInt64))
+          fmt.Sprintf("Found %s; Max: %d", YYtext, int64(math.MaxInt64)))
       } else {
         v *= 1024
       }
@@ -271,7 +271,7 @@ u?int(8|16|32)(be)? {
       if v > math.MaxInt64 / 1048576 {
         return Error(
           gyperror.IntegerOverflowError,
-          fmt.Sprintf("Found %s; Max: %d", YYtext, math.MaxInt64))
+          fmt.Sprintf("Found %s; Max: %d", YYtext, int64(math.MaxInt64)))
       } else {
           v *= 1048576
       }


### PR DESCRIPTION
Hi
I could not compile the library for 386 architecture (Go 1.16) because of untyped int constant overflow `math.MaxInt64` in `fmt.Sprintf` call. We have already been using `gyp` in production, I will be glad if you merge this PR.
Thank you.

Note: I fixed `lexer.l` and then generated `lexer.go` using `flexgo`.