### PR TITLE
Update .gitignore and cleanup Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.swp
 y2j
+j2y
 !y2j/
 y2j-linux
 y2j-mac

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ j2y:
 y2j:
 	go build github.com/VirusTotal/gyp/cmd/y2j
 
-release: parser lexer
+release:
 	GOOS=linux go build -o y2j-linux github.com/VirusTotal/gyp/cmd/y2j
 	GOOS=darwin go build -o y2j-mac github.com/VirusTotal/gyp/cmd/y2j
 	GOOS=windows go build -o y2j.exe github.com/VirusTotal/gyp/cmd/y2j


### PR DESCRIPTION
Update the .gitignore files to include *.swp and j2y.

While here, also fixup the Makefile as the release target is broken. It depends
upon two targets (parser and lexer) that do not exist. I'm guessing this
Makefile is not really used and is a holdover from the Northern-Lights repo?