### PR TITLE
Handle undefined string identifiers.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -28,6 +28,10 @@ type Expression interface {
 	AsProto() *pb.Expression
 }
 
+type StringExpression interface {
+	GetIdentifier() string
+}
+
 // Keyword is a Node that represents a keyword.
 type Keyword string
 
@@ -690,9 +694,14 @@ func (f *ForOf) Children() []Node {
 
 // Children returns the node's child nodes.
 func (o *Of) Children() []Node {
-	nodes := []Node{o.Quantifier, o.Strings}
+	// Because this node can have children that are exclusively rules or
+	// strings we need to only add them if they are non-nil.
+	nodes := []Node{o.Quantifier}
 	if o.Rules != nil {
 		nodes = append(nodes, o.Rules)
+	}
+	if o.Strings != nil {
+		nodes = append(nodes, o.Strings)
 	}
 	return nodes
 }
@@ -1234,4 +1243,19 @@ func (o *Operation) AsProto() *pb.Expression {
 	return expr
 }
 
+func (s *StringIdentifier) GetIdentifier() string {
+	return s.Identifier
+}
+
+func (s *StringOffset) GetIdentifier() string {
+	return s.Identifier
+}
+
+func (s *StringCount) GetIdentifier() string {
+	return s.Identifier
+}
+
+func (s *StringLength) GetIdentifier() string {
+	return s.Identifier
+}
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -28,10 +28,6 @@ type Expression interface {
 	AsProto() *pb.Expression
 }
 
-type StringExpression interface {
-	GetIdentifier() string
-}
-
 // Keyword is a Node that represents a keyword.
 type Keyword string
 
@@ -1242,20 +1238,3 @@ func (o *Operation) AsProto() *pb.Expression {
 	}
 	return expr
 }
-
-func (s *StringIdentifier) GetIdentifier() string {
-	return s.Identifier
-}
-
-func (s *StringOffset) GetIdentifier() string {
-	return s.Identifier
-}
-
-func (s *StringCount) GetIdentifier() string {
-	return s.Identifier
-}
-
-func (s *StringLength) GetIdentifier() string {
-	return s.Identifier
-}
-

--- a/error/error.go
+++ b/error/error.go
@@ -30,6 +30,7 @@ const (
 	UnevenNumberOfDigitsError
 	InvalidAsciiError
 	InvalidUTF8Error
+	UndefinedStringIdentifierError
 )
 
 type Error struct {

--- a/parser/adapter.go
+++ b/parser/adapter.go
@@ -32,6 +32,10 @@ func Parse(input io.Reader) (rs *ast.RuleSet, err error) {
 			Imports: make([]string, 0),
 			Rules:   make([]*ast.Rule, 0),
 		},
+		// Used to collect the strings as they are parsed on a per-rule basis.
+		// When the condition is parsed this is used as a lookup table to check
+		// for undefined strings.
+		strings: make(map[string]bool),
 	}
 	lexer.scanner.In = input
 	lexer.scanner.Out = ioutil.Discard
@@ -51,6 +55,7 @@ type lexer struct {
 	scanner Scanner
 	err     gyperror.Error
 	ruleSet *ast.RuleSet
+	strings map[string]bool
 }
 
 // Lex provides the interface expected by the goyacc parser. This function is

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -35,7 +35,7 @@ type stringModifiers struct {
 	Base64Alphabet string
 }
 
-//line parser/grammar.y:177
+//line parser/grammar.y:176
 type yrSymType struct {
 	yys       int
 	i64       int64
@@ -237,7 +237,7 @@ const yrEofCode = 1
 const yrErrCode = 2
 const yrInitialStackSize = 16
 
-//line parser/grammar.y:1256
+//line parser/grammar.y:1264
 
 // This function takes an operator and two operands and returns a Expression
 // representing the operation. If the left operand is an operation of the
@@ -255,6 +255,58 @@ func operation(operator ast.OperatorType, left, right ast.Expression) (n ast.Exp
 		}
 	}
 	return n
+}
+
+// Given the starting node of the AST and the rule to which the AST belongs,
+// walk all the children and find any string identifiers which are not defined.
+func checkStringIdentifiers(node ast.Node, rule *ast.Rule) []string {
+	missing_idents := []string{}
+typecheck:
+	switch v := node.(type) {
+	case ast.StringExpression:
+		// Anonymous strings allowed here as they are only allowed in loops and
+		// that is enforced by the parser already.
+		if v.GetIdentifier() == "" {
+			break
+		}
+
+		// Check for wildcards and use prefix matches.
+		if strings.HasSuffix(v.GetIdentifier(), "*") {
+			trimmed_ident := strings.TrimSuffix(v.GetIdentifier(), "*")
+			// Handle the case of "$*", there must be at least one defined string.
+			if len(trimmed_ident) == 0 && len(rule.Strings) == 0 {
+				missing_idents = append(missing_idents, "$*")
+				break
+			}
+
+			for _, s := range rule.Strings {
+				if strings.HasPrefix(s.GetIdentifier(), trimmed_ident) {
+					break typecheck
+				}
+			}
+		} else {
+			// Not a wildcard identifier, just see if it matches regularly.
+			for _, s := range rule.Strings {
+				if s.GetIdentifier() == v.GetIdentifier() {
+					break typecheck
+				}
+			}
+		}
+
+		// No defined string matches, it is an undefined string.
+		missing_idents = append(missing_idents, v.GetIdentifier())
+	case ast.Keyword:
+		// Special case of "them" with no strings defined.
+		if v == ast.KeywordThem && len(rule.Strings) == 0 {
+			missing_idents = append(missing_idents, string(v))
+		}
+	}
+
+	for _, child := range node.Children() {
+		missing_idents = append(missing_idents, checkStringIdentifiers(child, rule)...)
+	}
+
+	return missing_idents
 }
 
 //line yacctab:1
@@ -839,34 +891,34 @@ yrdefault:
 
 	case 2:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:227
+//line parser/grammar.y:226
 		{
 			ruleSet := asLexer(yrlex).ruleSet
 			ruleSet.Rules = append(ruleSet.Rules, yrDollar[2].rule)
 		}
 	case 3:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:232
+//line parser/grammar.y:231
 		{
 			ruleSet := asLexer(yrlex).ruleSet
 			ruleSet.Imports = append(ruleSet.Imports, yrDollar[2].s)
 		}
 	case 4:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:237
+//line parser/grammar.y:236
 		{
 			ruleSet := asLexer(yrlex).ruleSet
 			ruleSet.Includes = append(ruleSet.Includes, yrDollar[3].s)
 		}
 	case 5:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:242
+//line parser/grammar.y:241
 		{
 
 		}
 	case 6:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:250
+//line parser/grammar.y:249
 		{
 			if err := validateAscii(yrDollar[2].s); err != nil {
 				return asLexer(yrlex).setError(
@@ -877,7 +929,7 @@ yrdefault:
 		}
 	case 7:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:263
+//line parser/grammar.y:262
 		{
 			lexer := asLexer(yrlex)
 
@@ -908,7 +960,7 @@ yrdefault:
 		}
 	case 8:
 		yrDollar = yrS[yrpt-8 : yrpt+1]
-//line parser/grammar.y:292
+//line parser/grammar.y:291
 		{
 			// Check for duplicate strings.
 			m := make(map[string]bool)
@@ -932,51 +984,60 @@ yrdefault:
 		}
 	case 9:
 		yrDollar = yrS[yrpt-11 : yrpt+1]
-//line parser/grammar.y:314
+//line parser/grammar.y:313
 		{
+			// Walk the condition AST looking for string identifiers that are not
+			// defined in the strings section.
+			missing_idents := checkStringIdentifiers(yrDollar[10].expr, yrDollar[4].rule)
+			if len(missing_idents) > 0 {
+				return asLexer(yrlex).setError(
+					gyperror.UndefinedStringIdentifierError,
+					`rule "%s": undefined string identifiers: %s`,
+					yrDollar[4].rule.Identifier, strings.Join(missing_idents[:], ", "))
+			}
 			yrDollar[4].rule.Condition = yrDollar[10].expr
 			yrVAL.rule = yrDollar[4].rule
 		}
 	case 10:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:323
+//line parser/grammar.y:331
 		{
 			yrVAL.metas = []*ast.Meta{}
 		}
 	case 11:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:327
+//line parser/grammar.y:335
 		{
 			yrVAL.metas = yrDollar[3].metas
 		}
 	case 12:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:335
+//line parser/grammar.y:343
 		{
 			yrVAL.yss = []ast.String{}
 		}
 	case 13:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:339
+//line parser/grammar.y:347
 		{
 			yrVAL.yss = yrDollar[3].yss
 		}
 	case 14:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:347
+//line parser/grammar.y:355
 		{
 			yrVAL.expr = yrDollar[3].expr
 		}
 	case 15:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:355
+//line parser/grammar.y:363
 		{
 			yrVAL.mod = 0
 			yrVAL.lineno = -1
 		}
 	case 16:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:360
+//line parser/grammar.y:368
 		{
 			yrVAL.mod = yrDollar[1].mod | yrDollar[2].mod
 
@@ -988,39 +1049,39 @@ yrdefault:
 		}
 	case 17:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:374
+//line parser/grammar.y:382
 		{
 			yrVAL.mod = ModPrivate
 			yrVAL.lineno = yrDollar[1].lineno
 		}
 	case 18:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:379
+//line parser/grammar.y:387
 		{
 			yrVAL.mod = ModGlobal
 			yrVAL.lineno = yrDollar[1].lineno
 		}
 	case 19:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:388
+//line parser/grammar.y:396
 		{
 			yrVAL.ss = []string{}
 		}
 	case 20:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:392
+//line parser/grammar.y:400
 		{
 			yrVAL.ss = yrDollar[2].ss
 		}
 	case 21:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:400
+//line parser/grammar.y:408
 		{
 			yrVAL.ss = []string{yrDollar[1].s}
 		}
 	case 22:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:404
+//line parser/grammar.y:412
 		{
 			lexer := asLexer(yrlex)
 
@@ -1035,19 +1096,19 @@ yrdefault:
 		}
 	case 23:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:421
+//line parser/grammar.y:429
 		{
 			yrVAL.metas = []*ast.Meta{yrDollar[1].meta}
 		}
 	case 24:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:425
+//line parser/grammar.y:433
 		{
 			yrVAL.metas = append(yrDollar[1].metas, yrDollar[2].meta)
 		}
 	case 25:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:433
+//line parser/grammar.y:441
 		{
 			yrVAL.meta = &ast.Meta{
 				Key:   yrDollar[1].s,
@@ -1056,7 +1117,7 @@ yrdefault:
 		}
 	case 26:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:440
+//line parser/grammar.y:448
 		{
 			yrVAL.meta = &ast.Meta{
 				Key:   yrDollar[1].s,
@@ -1065,7 +1126,7 @@ yrdefault:
 		}
 	case 27:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:447
+//line parser/grammar.y:455
 		{
 			yrVAL.meta = &ast.Meta{
 				Key:   yrDollar[1].s,
@@ -1074,7 +1135,7 @@ yrdefault:
 		}
 	case 28:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:454
+//line parser/grammar.y:462
 		{
 			yrVAL.meta = &ast.Meta{
 				Key:   yrDollar[1].s,
@@ -1083,7 +1144,7 @@ yrdefault:
 		}
 	case 29:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:461
+//line parser/grammar.y:469
 		{
 			yrVAL.meta = &ast.Meta{
 				Key:   yrDollar[1].s,
@@ -1092,19 +1153,19 @@ yrdefault:
 		}
 	case 30:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:472
+//line parser/grammar.y:480
 		{
 			yrVAL.yss = []ast.String{yrDollar[1].ys}
 		}
 	case 31:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:476
+//line parser/grammar.y:484
 		{
 			yrVAL.yss = append(yrDollar[1].yss, yrDollar[2].ys)
 		}
 	case 32:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:484
+//line parser/grammar.y:492
 		{
 			if err := validateUTF8(yrDollar[3].s); err != nil {
 				return asLexer(yrlex).setError(
@@ -1113,7 +1174,7 @@ yrdefault:
 		}
 	case 33:
 		yrDollar = yrS[yrpt-5 : yrpt+1]
-//line parser/grammar.y:491
+//line parser/grammar.y:499
 		{
 			yrVAL.ys = &ast.TextString{
 				BaseString: ast.BaseString{
@@ -1136,7 +1197,7 @@ yrdefault:
 		}
 	case 34:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:512
+//line parser/grammar.y:520
 		{
 			yrVAL.ys = &ast.RegexpString{
 				BaseString: ast.BaseString{
@@ -1153,7 +1214,7 @@ yrdefault:
 		}
 	case 35:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:527
+//line parser/grammar.y:535
 		{
 			yrVAL.ys = &ast.HexString{
 				BaseString: ast.BaseString{
@@ -1166,13 +1227,13 @@ yrdefault:
 		}
 	case 36:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:542
+//line parser/grammar.y:550
 		{
 			yrVAL.smod = stringModifiers{}
 		}
 	case 37:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:546
+//line parser/grammar.y:554
 		{
 			if yrDollar[1].smod.modifiers&yrDollar[2].smod.modifiers != 0 {
 				return asLexer(yrlex).setError(
@@ -1194,49 +1255,49 @@ yrdefault:
 		}
 	case 38:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:569
+//line parser/grammar.y:577
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModWide}
 		}
 	case 39:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:570
+//line parser/grammar.y:578
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModASCII}
 		}
 	case 40:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:571
+//line parser/grammar.y:579
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModNocase}
 		}
 	case 41:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:572
+//line parser/grammar.y:580
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModFullword}
 		}
 	case 42:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:573
+//line parser/grammar.y:581
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModPrivate}
 		}
 	case 43:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:574
+//line parser/grammar.y:582
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModBase64}
 		}
 	case 44:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:575
+//line parser/grammar.y:583
 		{
 			yrVAL.smod = stringModifiers{modifiers: ModBase64Wide}
 		}
 	case 45:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:577
+//line parser/grammar.y:585
 		{
 			if err := validateAscii(yrDollar[3].s); err != nil {
 				return asLexer(yrlex).setError(
@@ -1256,7 +1317,7 @@ yrdefault:
 		}
 	case 46:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:595
+//line parser/grammar.y:603
 		{
 			if err := validateAscii(yrDollar[3].s); err != nil {
 				return asLexer(yrlex).setError(
@@ -1276,7 +1337,7 @@ yrdefault:
 		}
 	case 47:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:613
+//line parser/grammar.y:621
 		{
 			yrVAL.smod = stringModifiers{
 				modifiers: ModXor,
@@ -1286,7 +1347,7 @@ yrdefault:
 		}
 	case 48:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:621
+//line parser/grammar.y:629
 		{
 			yrVAL.smod = stringModifiers{
 				modifiers: ModXor,
@@ -1296,7 +1357,7 @@ yrdefault:
 		}
 	case 49:
 		yrDollar = yrS[yrpt-6 : yrpt+1]
-//line parser/grammar.y:629
+//line parser/grammar.y:637
 		{
 			lexer := asLexer(yrlex)
 
@@ -1326,73 +1387,73 @@ yrdefault:
 		}
 	case 50:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:661
+//line parser/grammar.y:669
 		{
 			yrVAL.mod = 0
 		}
 	case 51:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:665
+//line parser/grammar.y:673
 		{
 			yrVAL.mod = yrDollar[1].mod | yrDollar[2].mod
 		}
 	case 52:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:672
+//line parser/grammar.y:680
 		{
 			yrVAL.mod = ModWide
 		}
 	case 53:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:673
+//line parser/grammar.y:681
 		{
 			yrVAL.mod = ModASCII
 		}
 	case 54:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:674
+//line parser/grammar.y:682
 		{
 			yrVAL.mod = ModNocase
 		}
 	case 55:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:675
+//line parser/grammar.y:683
 		{
 			yrVAL.mod = ModFullword
 		}
 	case 56:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:676
+//line parser/grammar.y:684
 		{
 			yrVAL.mod = ModPrivate
 		}
 	case 57:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:682
+//line parser/grammar.y:690
 		{
 			yrVAL.mod = 0
 		}
 	case 58:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:686
+//line parser/grammar.y:694
 		{
 			yrVAL.mod = yrDollar[1].mod | yrDollar[2].mod
 		}
 	case 59:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:693
+//line parser/grammar.y:701
 		{
 			yrVAL.mod = ModPrivate
 		}
 	case 60:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:699
+//line parser/grammar.y:707
 		{
 			yrVAL.expr = &ast.Identifier{Identifier: yrDollar[1].s}
 		}
 	case 61:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:703
+//line parser/grammar.y:711
 		{
 			yrVAL.expr = &ast.MemberAccess{
 				Container: yrDollar[1].expr,
@@ -1401,7 +1462,7 @@ yrdefault:
 		}
 	case 62:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:710
+//line parser/grammar.y:718
 		{
 			yrVAL.expr = &ast.Subscripting{
 				Array: yrDollar[1].expr,
@@ -1410,7 +1471,7 @@ yrdefault:
 		}
 	case 63:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:717
+//line parser/grammar.y:725
 		{
 			yrVAL.expr = &ast.FunctionCall{
 				Callable:  yrDollar[1].expr,
@@ -1419,55 +1480,55 @@ yrdefault:
 		}
 	case 64:
 		yrDollar = yrS[yrpt-0 : yrpt+1]
-//line parser/grammar.y:728
+//line parser/grammar.y:736
 		{
 			yrVAL.exprs = []ast.Expression{}
 		}
 	case 65:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:732
+//line parser/grammar.y:740
 		{
 			yrVAL.exprs = yrDollar[1].exprs
 		}
 	case 66:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:739
+//line parser/grammar.y:747
 		{
 			yrVAL.exprs = []ast.Expression{yrDollar[1].expr}
 		}
 	case 67:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:743
+//line parser/grammar.y:751
 		{
 			yrVAL.exprs = append(yrDollar[1].exprs, yrDollar[3].expr)
 		}
 	case 68:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:751
+//line parser/grammar.y:759
 		{
 			yrVAL.reg = yrDollar[1].reg
 		}
 	case 69:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:759
+//line parser/grammar.y:767
 		{
 			yrVAL.expr = yrDollar[1].expr
 		}
 	case 70:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:767
+//line parser/grammar.y:775
 		{
 			yrVAL.expr = ast.KeywordTrue
 		}
 	case 71:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:771
+//line parser/grammar.y:779
 		{
 			yrVAL.expr = ast.KeywordFalse
 		}
 	case 72:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:775
+//line parser/grammar.y:783
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpMatches,
@@ -1476,7 +1537,7 @@ yrdefault:
 		}
 	case 73:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:782
+//line parser/grammar.y:790
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpContains,
@@ -1485,7 +1546,7 @@ yrdefault:
 		}
 	case 74:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:789
+//line parser/grammar.y:797
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpIContains,
@@ -1494,7 +1555,7 @@ yrdefault:
 		}
 	case 75:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:796
+//line parser/grammar.y:804
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpStartsWith,
@@ -1503,7 +1564,7 @@ yrdefault:
 		}
 	case 76:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:803
+//line parser/grammar.y:811
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpIStartsWith,
@@ -1512,7 +1573,7 @@ yrdefault:
 		}
 	case 77:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:810
+//line parser/grammar.y:818
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpEndsWith,
@@ -1521,7 +1582,7 @@ yrdefault:
 		}
 	case 78:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:817
+//line parser/grammar.y:825
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpIEndsWith,
@@ -1530,7 +1591,7 @@ yrdefault:
 		}
 	case 79:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:824
+//line parser/grammar.y:832
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpIEquals,
@@ -1539,7 +1600,7 @@ yrdefault:
 		}
 	case 80:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:831
+//line parser/grammar.y:839
 		{
 			yrVAL.expr = &ast.StringIdentifier{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "$"),
@@ -1547,7 +1608,7 @@ yrdefault:
 		}
 	case 81:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:837
+//line parser/grammar.y:845
 		{
 			yrVAL.expr = &ast.StringIdentifier{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "$"),
@@ -1556,7 +1617,7 @@ yrdefault:
 		}
 	case 82:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:844
+//line parser/grammar.y:852
 		{
 			yrVAL.expr = &ast.StringIdentifier{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "$"),
@@ -1565,7 +1626,7 @@ yrdefault:
 		}
 	case 83:
 		yrDollar = yrS[yrpt-9 : yrpt+1]
-//line parser/grammar.y:851
+//line parser/grammar.y:859
 		{
 			yrVAL.expr = &ast.ForIn{
 				Quantifier: yrDollar[2].expr,
@@ -1576,7 +1637,7 @@ yrdefault:
 		}
 	case 84:
 		yrDollar = yrS[yrpt-8 : yrpt+1]
-//line parser/grammar.y:860
+//line parser/grammar.y:868
 		{
 			yrVAL.expr = &ast.ForOf{
 				Quantifier: yrDollar[2].expr,
@@ -1586,7 +1647,7 @@ yrdefault:
 		}
 	case 85:
 		yrDollar = yrS[yrpt-5 : yrpt+1]
-//line parser/grammar.y:868
+//line parser/grammar.y:876
 		{
 			yrVAL.expr = &ast.Of{
 				Quantifier: yrDollar[1].expr,
@@ -1596,7 +1657,7 @@ yrdefault:
 		}
 	case 86:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:876
+//line parser/grammar.y:884
 		{
 			yrVAL.expr = &ast.Of{
 				Quantifier: yrDollar[1].expr,
@@ -1605,7 +1666,7 @@ yrdefault:
 		}
 	case 87:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:883
+//line parser/grammar.y:891
 		{
 			yrVAL.expr = &ast.Of{
 				Quantifier: yrDollar[1].expr,
@@ -1614,7 +1675,7 @@ yrdefault:
 		}
 	case 88:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:890
+//line parser/grammar.y:898
 		{
 			yrVAL.expr = &ast.Of{
 				Quantifier: &ast.Percentage{yrDollar[1].expr},
@@ -1623,7 +1684,7 @@ yrdefault:
 		}
 	case 89:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:897
+//line parser/grammar.y:905
 		{
 			yrVAL.expr = &ast.Of{
 				Quantifier: &ast.Percentage{yrDollar[1].expr},
@@ -1632,31 +1693,31 @@ yrdefault:
 		}
 	case 90:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:904
+//line parser/grammar.y:912
 		{
 			yrVAL.expr = &ast.Not{yrDollar[2].expr}
 		}
 	case 91:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:908
+//line parser/grammar.y:916
 		{
 			yrVAL.expr = &ast.Defined{yrDollar[2].expr}
 		}
 	case 92:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:912
+//line parser/grammar.y:920
 		{
 			yrVAL.expr = operation(ast.OpAnd, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 93:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:916
+//line parser/grammar.y:924
 		{
 			yrVAL.expr = operation(ast.OpOr, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 94:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:920
+//line parser/grammar.y:928
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpLessThan,
@@ -1665,7 +1726,7 @@ yrdefault:
 		}
 	case 95:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:927
+//line parser/grammar.y:935
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpGreaterThan,
@@ -1674,7 +1735,7 @@ yrdefault:
 		}
 	case 96:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:934
+//line parser/grammar.y:942
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpLessOrEqual,
@@ -1683,7 +1744,7 @@ yrdefault:
 		}
 	case 97:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:941
+//line parser/grammar.y:949
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpGreaterOrEqual,
@@ -1692,7 +1753,7 @@ yrdefault:
 		}
 	case 98:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:948
+//line parser/grammar.y:956
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpEqual,
@@ -1701,7 +1762,7 @@ yrdefault:
 		}
 	case 99:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:955
+//line parser/grammar.y:963
 		{
 			yrVAL.expr = &ast.Operation{
 				Operator: ast.OpNotEqual,
@@ -1710,31 +1771,31 @@ yrdefault:
 		}
 	case 100:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:962
+//line parser/grammar.y:970
 		{
 			yrVAL.expr = yrDollar[1].expr
 		}
 	case 101:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:966
+//line parser/grammar.y:974
 		{
 			yrVAL.expr = &ast.Group{yrDollar[2].expr}
 		}
 	case 102:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:974
+//line parser/grammar.y:982
 		{
 			yrVAL.node = &ast.Enum{Values: yrDollar[2].exprs}
 		}
 	case 103:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:978
+//line parser/grammar.y:986
 		{
 			yrVAL.node = yrDollar[1].rng
 		}
 	case 104:
 		yrDollar = yrS[yrpt-5 : yrpt+1]
-//line parser/grammar.y:986
+//line parser/grammar.y:994
 		{
 			yrVAL.rng = &ast.Range{
 				Start: yrDollar[2].expr,
@@ -1743,43 +1804,43 @@ yrdefault:
 		}
 	case 105:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:997
+//line parser/grammar.y:1005
 		{
 			yrVAL.exprs = []ast.Expression{yrDollar[1].expr}
 		}
 	case 106:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1001
+//line parser/grammar.y:1009
 		{
 			yrVAL.exprs = append(yrDollar[1].exprs, yrDollar[3].expr)
 		}
 	case 107:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1009
+//line parser/grammar.y:1017
 		{
 			yrVAL.node = &ast.Enum{Values: yrDollar[2].exprs}
 		}
 	case 108:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1013
+//line parser/grammar.y:1021
 		{
 			yrVAL.node = ast.KeywordThem
 		}
 	case 109:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1021
+//line parser/grammar.y:1029
 		{
 			yrVAL.exprs = []ast.Expression{yrDollar[1].si}
 		}
 	case 110:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1025
+//line parser/grammar.y:1033
 		{
 			yrVAL.exprs = append(yrDollar[1].exprs, yrDollar[3].si)
 		}
 	case 111:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1033
+//line parser/grammar.y:1041
 		{
 			yrVAL.si = &ast.StringIdentifier{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "$"),
@@ -1787,7 +1848,7 @@ yrdefault:
 		}
 	case 112:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1039
+//line parser/grammar.y:1047
 		{
 			yrVAL.si = &ast.StringIdentifier{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "$"),
@@ -1795,103 +1856,103 @@ yrdefault:
 		}
 	case 113:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1049
+//line parser/grammar.y:1057
 		{
 			yrVAL.node = &ast.Enum{Values: yrDollar[2].exprs}
 		}
 	case 114:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1057
+//line parser/grammar.y:1065
 		{
 			yrVAL.exprs = []ast.Expression{yrDollar[1].ident}
 		}
 	case 115:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1061
+//line parser/grammar.y:1069
 		{
 			yrVAL.exprs = append(yrDollar[1].exprs, yrDollar[3].ident)
 		}
 	case 116:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1069
+//line parser/grammar.y:1077
 		{
 			yrVAL.ident = &ast.Identifier{Identifier: yrDollar[1].s}
 		}
 	case 117:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:1073
+//line parser/grammar.y:1081
 		{
 			yrVAL.ident = &ast.Identifier{Identifier: yrDollar[1].s + "*"}
 		}
 	case 118:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1081
+//line parser/grammar.y:1089
 		{
 			yrVAL.expr = yrDollar[1].expr
 		}
 	case 119:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1085
+//line parser/grammar.y:1093
 		{
 			yrVAL.expr = ast.KeywordAll
 		}
 	case 120:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1089
+//line parser/grammar.y:1097
 		{
 			yrVAL.expr = ast.KeywordAny
 		}
 	case 121:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1093
+//line parser/grammar.y:1101
 		{
 			yrVAL.expr = ast.KeywordNone
 		}
 	case 122:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1101
+//line parser/grammar.y:1109
 		{
 			yrVAL.ss = []string{yrDollar[1].s}
 		}
 	case 123:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1105
+//line parser/grammar.y:1113
 		{
 			yrVAL.ss = append(yrDollar[1].ss, yrDollar[3].s)
 		}
 	case 124:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1112
+//line parser/grammar.y:1120
 		{
 			yrVAL.node = yrDollar[1].expr
 		}
 	case 125:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1116
+//line parser/grammar.y:1124
 		{
 			yrVAL.node = yrDollar[1].node
 		}
 	case 126:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1124
+//line parser/grammar.y:1132
 		{
 			yrVAL.expr = &ast.Group{yrDollar[2].expr}
 		}
 	case 127:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1128
+//line parser/grammar.y:1136
 		{
 			yrVAL.expr = ast.KeywordFilesize
 		}
 	case 128:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1132
+//line parser/grammar.y:1140
 		{
 			yrVAL.expr = ast.KeywordEntrypoint
 		}
 	case 129:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:1136
+//line parser/grammar.y:1144
 		{
 			yrVAL.expr = &ast.FunctionCall{
 				Callable:  &ast.Identifier{Identifier: yrDollar[1].s},
@@ -1900,19 +1961,19 @@ yrdefault:
 		}
 	case 130:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1143
+//line parser/grammar.y:1151
 		{
 			yrVAL.expr = &ast.LiteralInteger{yrDollar[1].i64}
 		}
 	case 131:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1147
+//line parser/grammar.y:1155
 		{
 			yrVAL.expr = &ast.LiteralFloat{yrDollar[1].f64}
 		}
 	case 132:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1151
+//line parser/grammar.y:1159
 		{
 			if err := validateUTF8(yrDollar[1].s); err != nil {
 				return asLexer(yrlex).setError(
@@ -1923,7 +1984,7 @@ yrdefault:
 		}
 	case 133:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1160
+//line parser/grammar.y:1168
 		{
 			yrVAL.expr = &ast.StringCount{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "#"),
@@ -1932,7 +1993,7 @@ yrdefault:
 		}
 	case 134:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1167
+//line parser/grammar.y:1175
 		{
 			yrVAL.expr = &ast.StringCount{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "#"),
@@ -1940,7 +2001,7 @@ yrdefault:
 		}
 	case 135:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:1173
+//line parser/grammar.y:1181
 		{
 			yrVAL.expr = &ast.StringOffset{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "@"),
@@ -1949,7 +2010,7 @@ yrdefault:
 		}
 	case 136:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1180
+//line parser/grammar.y:1188
 		{
 			yrVAL.expr = &ast.StringOffset{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "@"),
@@ -1957,7 +2018,7 @@ yrdefault:
 		}
 	case 137:
 		yrDollar = yrS[yrpt-4 : yrpt+1]
-//line parser/grammar.y:1186
+//line parser/grammar.y:1194
 		{
 			yrVAL.expr = &ast.StringLength{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "!"),
@@ -1966,7 +2027,7 @@ yrdefault:
 		}
 	case 138:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1193
+//line parser/grammar.y:1201
 		{
 			yrVAL.expr = &ast.StringLength{
 				Identifier: strings.TrimPrefix(yrDollar[1].s, "!"),
@@ -1974,85 +2035,85 @@ yrdefault:
 		}
 	case 139:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1199
+//line parser/grammar.y:1207
 		{
 			yrVAL.expr = yrDollar[1].expr
 		}
 	case 140:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:1203
+//line parser/grammar.y:1211
 		{
 			yrVAL.expr = &ast.Minus{yrDollar[2].expr}
 		}
 	case 141:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1207
+//line parser/grammar.y:1215
 		{
 			yrVAL.expr = operation(ast.OpAdd, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 142:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1211
+//line parser/grammar.y:1219
 		{
 			yrVAL.expr = operation(ast.OpSub, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 143:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1215
+//line parser/grammar.y:1223
 		{
 			yrVAL.expr = operation(ast.OpMul, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 144:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1219
+//line parser/grammar.y:1227
 		{
 			yrVAL.expr = operation(ast.OpDiv, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 145:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1223
+//line parser/grammar.y:1231
 		{
 			yrVAL.expr = operation(ast.OpMod, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 146:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1227
+//line parser/grammar.y:1235
 		{
 			yrVAL.expr = operation(ast.OpBitXor, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 147:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1231
+//line parser/grammar.y:1239
 		{
 			yrVAL.expr = operation(ast.OpBitAnd, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 148:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1235
+//line parser/grammar.y:1243
 		{
 			yrVAL.expr = operation(ast.OpBitOr, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 149:
 		yrDollar = yrS[yrpt-2 : yrpt+1]
-//line parser/grammar.y:1239
+//line parser/grammar.y:1247
 		{
 			yrVAL.expr = &ast.BitwiseNot{yrDollar[2].expr}
 		}
 	case 150:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1243
+//line parser/grammar.y:1251
 		{
 			yrVAL.expr = operation(ast.OpShiftLeft, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 151:
 		yrDollar = yrS[yrpt-3 : yrpt+1]
-//line parser/grammar.y:1247
+//line parser/grammar.y:1255
 		{
 			yrVAL.expr = operation(ast.OpShiftRight, yrDollar[1].expr, yrDollar[3].expr)
 		}
 	case 152:
 		yrDollar = yrS[yrpt-1 : yrpt+1]
-//line parser/grammar.y:1251
+//line parser/grammar.y:1259
 		{
 			yrVAL.expr = yrDollar[1].reg
 		}

--- a/tests/grammar_test.go
+++ b/tests/grammar_test.go
@@ -467,21 +467,21 @@ func TestUndefinedStringIdentifier(t *testing.T) {
 		strings:
 			$a = "AXSERS"
 		condition:
-			$s and $t
+			$s
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 7: rule "UNDEFINED_STRING_IDENTIFIER": undefined string identifiers: s, t`, err.Error())
+		assert.Equal(t, `line 7: undefined string identifier: $s`, err.Error())
 	}
 }
 
-func TestUndefinedStringIdentifierEnumeration(t *testing.T) {
+func TestUndefinedStringKeywordNoStrings(t *testing.T) {
 	_, err := gyp.ParseString(`
-	rule UNDEFINED_STRING_IDENTIFIER_IN_STRING_ENUMERATION {
+	rule UNDEFINED_STRING_KEYWORD_NO_STRINGS {
 		condition:
 			1 of them
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_IN_STRING_ENUMERATION": undefined string identifiers: them`, err.Error())
+		assert.Equal(t, `line 4: undefined string identifier: them`, err.Error())
 	}
 }
 
@@ -492,11 +492,11 @@ func TestUndefinedStringIdentifierWildcard(t *testing.T) {
 			1 of ($s*)
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD": undefined string identifiers: s*`, err.Error())
+		assert.Equal(t, `line 4: undefined string identifier: $s*`, err.Error())
 	}
 }
 
-// Make sure wildcard expansion works!
+// Make sure wildcard expansion still works.
 func TestUndefinedStringIdentifierWildcardExpansion(t *testing.T) {
 	_, err := gyp.ParseString(`
 	rule UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD_2 {
@@ -506,40 +506,189 @@ func TestUndefinedStringIdentifierWildcardExpansion(t *testing.T) {
 			1 of ($s*) and $x
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 7: rule "UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD_2": undefined string identifiers: x`, err.Error())
+		assert.Equal(t, `line 7: undefined string identifier: $x`, err.Error())
 	}
 }
 
 func TestUndefinedStringCount(t *testing.T) {
 	_, err := gyp.ParseString(`
-	rule UNDEFINED_STRING_IDENTIFIER_COUNT {
+	rule UNDEFINED_STRING_COUNT {
 		condition:
 			#s > 0
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_COUNT": undefined string identifiers: s`, err.Error())
+		assert.Equal(t, `line 4: undefined string identifier: #s`, err.Error())
 	}
+}
+
+// Make sure anonymous string counts are allowed.
+func TestUndefinedStringCountAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_COUNT_ANONYMOUS {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (# > 10)
+	}`)
+	assert.NoError(t, err)
 }
 
 func TestUndefinedStringOffset(t *testing.T) {
 	_, err := gyp.ParseString(`
-	rule UNDEFINED_STRING_IDENTIFIER_OFFSET {
+	rule UNDEFINED_STRING_OFFSET {
 		condition:
 			@s[0] > 0
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_OFFSET": undefined string identifiers: s`, err.Error())
+		assert.Equal(t, `line 4: undefined string identifier: @s`, err.Error())
 	}
+}
+
+// Make sure anonymous string offsets are allowed.
+func TestUndefinedStringOffsetAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_OFFSET_ANONYMOUS {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (@ > 10)
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringOffsetAnonymousExpression(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_OFFSET_ANONYMOUS_EXPRESSION {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (@[1] > 10)
+	}`)
+	assert.NoError(t, err)
 }
 
 func TestUndefinedStringLength(t *testing.T) {
 	_, err := gyp.ParseString(`
-	rule UNDEFINED_STRING_IDENTIFIER_LENGTH {
+	rule UNDEFINED_STRING_LENGTH {
 		condition:
 			!s == 40
 	}`)
 	if assert.Error(t, err) {
-		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_LENGTH": undefined string identifiers: s`, err.Error())
+		assert.Equal(t, `line 4: undefined string identifier: !s`, err.Error())
+	}
+}
+
+// Make sure anonymous string lengths are allowed.
+func TestUndefinedStringLengthAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_LENGTH_ANONYMOUS {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (! > 5)
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringLengthAnonymousExpression(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_LENGTH_ANONYMOUS_EXPRESSION {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (![1] > 5)
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringAt(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_AT {
+		condition:
+			$s at 10
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: undefined string identifier: $s`, err.Error())
+	}
+}
+
+// Make sure anonymous string at are allowed.
+func TestUndefinedStringAtAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_AT_ANONYMOUS {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: ($ at 5)
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringInRange(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IN_RANGE {
+		condition:
+			$s in (0..10)
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 4: undefined string identifier: $s`, err.Error())
+	}
+}
+
+// Make sure anonymous string in range is allowed.
+func TestUndefinedStringInRangeAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IN_RANGE_ANONYMOUS {
+		strings:
+		  $s = "AXSERS"
+		condition:
+		    for any of them: ($ in (0..10))
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringInRangeAnonymousExpression(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IN_RANGE_ANONYMOUS_EXPRESSION {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: ($ in (0..10))
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringCountInRange(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_COUNT_IN_RANGE {
+		condition:
+			#s in (0..10) == 2
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 4: undefined string identifier: #s`, err.Error())
+	}
+}
+
+// Make sure anonymous string count in range is allowed.
+func TestUndefinedStringCountInRangeAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_COUNT_IN_RANGE_ANONYMOUS {
+		strings:
+			$s = "AXSERS"
+		condition:
+			for any of them: (# in (0..10) == 2)
+	}`)
+	assert.NoError(t, err)
+}
+
+func TestUndefinedStringEnumerationAnonymous(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_ENUMERATION_ANONYMOUS {
+		condition:
+			any of ($)
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 4: undefined string identifier: $`, err.Error())
 	}
 }
 

--- a/tests/grammar_test.go
+++ b/tests/grammar_test.go
@@ -286,6 +286,7 @@ rule AND_OR_PRECEDENCE_NO_PARENS {
     $foo1 = "foo1"
     $foo2 = /foo2/
     $foo3 = { AA BB CC }
+    $foo4 = "I AM A STRING! ;)"
   condition:
     $foo1 or $foo2 or $foo3 and $foo4
 }
@@ -295,6 +296,7 @@ rule AND_OR_PRECEDENCE_PARENS {
     $foo1 = "foo1"
     $foo2 = /foo2/
     $foo3 = { AA BB CC }
+    $foo4 = "I AM A STRING! ;)"
   condition:
     ($foo1 or $foo2 or $foo3) and $foo4
 }
@@ -456,6 +458,88 @@ func TestDuplicateStringModifiers(t *testing.T) {
 	}`)
 	if assert.Error(t, err) {
 		assert.Equal(t, "line 5: duplicate modifier", err.Error())
+	}
+}
+
+func TestUndefinedStringIdentifier(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER {
+		strings:
+			$a = "AXSERS"
+		condition:
+			$s and $t
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 7: rule "UNDEFINED_STRING_IDENTIFIER": undefined string identifiers: s, t`, err.Error())
+	}
+}
+
+func TestUndefinedStringIdentifierEnumeration(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_IN_STRING_ENUMERATION {
+		condition:
+			1 of them
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_IN_STRING_ENUMERATION": undefined string identifiers: them`, err.Error())
+	}
+}
+
+func TestUndefinedStringIdentifierWildcard(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD {
+		condition:
+			1 of ($s*)
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD": undefined string identifiers: s*`, err.Error())
+	}
+}
+
+// Make sure wildcard expansion works!
+func TestUndefinedStringIdentifierWildcardExpansion(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD_2 {
+		strings:
+			$s0 = "AXSERS"
+		condition:
+			1 of ($s*) and $x
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 7: rule "UNDEFINED_STRING_IDENTIFIER_WITH_WILDCARD_2": undefined string identifiers: x`, err.Error())
+	}
+}
+
+func TestUndefinedStringCount(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_COUNT {
+		condition:
+			#s > 0
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_COUNT": undefined string identifiers: s`, err.Error())
+	}
+}
+
+func TestUndefinedStringOffset(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_OFFSET {
+		condition:
+			@s[0] > 0
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_OFFSET": undefined string identifiers: s`, err.Error())
+	}
+}
+
+func TestUndefinedStringLength(t *testing.T) {
+	_, err := gyp.ParseString(`
+	rule UNDEFINED_STRING_IDENTIFIER_LENGTH {
+		condition:
+			!s == 40
+	}`)
+	if assert.Error(t, err) {
+		assert.Equal(t, `line 5: rule "UNDEFINED_STRING_IDENTIFIER_LENGTH": undefined string identifiers: s`, err.Error())
 	}
 }
 


### PR DESCRIPTION
When parsing rules gyp does not complain about undefined string identifiers.

For example, it does not error when parsing this rule:

rule a { condition: $x }

With these changes it now walks the condition AST and makes sure all string
references are valid, including wildcard expansion.

While I'm here I uncovered a slight error with the Children() method on the Of
node, where it would always set the Strings to nil if there were none, which is
now fixed.

I also discovered some existing tests that were broken by this (they did not
have a $foo4 string defined) so I "fixed" those too.