### PR TITLE
Dependency walker fix

### DIFF
--- a/utils/dependency_walker.go
+++ b/utils/dependency_walker.go
@@ -106,9 +106,7 @@ func SortRules(rs ast.RuleSet) ast.RuleSet {
 	return rs
 }
 
-// GetDependenciesForRules will find all the dependencies (rules & imports)
-// for rules listed in ruleNames. The returned ruleset will only contain rules
-// listed in ruleNames along with their dependencies (direct & indirect).
+// GetDependenciesForRules returns a ruleset containing dependencies (direct/indirect) for a list of given rules
 func GetDependenciesForRules(ruleset ast.RuleSet, ruleNames ...string) (ast.RuleSet, error) {
 	// Make sure ruleNames and ruleset are not empty
 	if len(ruleset.Rules) == 0 {

--- a/utils/dependency_walker.go
+++ b/utils/dependency_walker.go
@@ -6,7 +6,7 @@ import (
 	"github.com/VirusTotal/gyp/ast"
 )
 
-var yaraModules = []string{"pe", "elf", "cuckoo", "magic", "hash", "math", "dotnet", "time", "dex"}
+var yaraModules = []string{"pe", "elf", "cuckoo", "magic", "hash", "math", "dotnet", "time", "dex", "console"}
 
 type queueT struct {
 	node       ast.Node


### PR DESCRIPTION
Added `console` module to yaraModules.

Changed `GetDependenciesForRules`'s comment to be easier to understand. 