### PR TITLE
Fixed check in ranges for equal bounds

### DIFF
--- a/parser/grammar.y
+++ b/parser/grammar.y
@@ -1063,7 +1063,7 @@ range
       {
         if start, ok := $2.(*ast.LiteralInteger); ok {
           if end, ok := $4.(*ast.LiteralInteger); ok {
-            if (start.Value >= end.Value) {
+            if (start.Value > end.Value) {
               lexer := asLexer(yrlex)
               return lexer.setError(
                 gyperror.InvalidValueError,

--- a/tests/grammar_test.go
+++ b/tests/grammar_test.go
@@ -834,6 +834,7 @@ func TestNegativeUpperRange(t *testing.T) {
 		assert.Equal(t, "line 6: upper bound can not be negative", err.Error())
 	}
 }
+
 func TestInvalidRange(t *testing.T) {
 	_, err := gyp.ParseString(`
     rule INVALID_RANGE {
@@ -845,6 +846,17 @@ func TestInvalidRange(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Equal(t, "line 6: lower bound must be less than upper bound", err.Error())
 	}
+}
+
+func TestEqualBoundsRange(t *testing.T) {
+	_, err := gyp.ParseString(`
+    rule EQUAL_BOUNDS_RANGE {
+	  strings:
+	    $a = "AXSERS"
+      condition:
+        $a in (1..1)
+    }`)
+	assert.NoError(t, err)
 }
 
 // { ~?? } is an error


### PR DESCRIPTION
This is correct in YARA but invalid in gyp. The ranges include both ends of bounds so something like `1..1` is still valid.